### PR TITLE
Adding TLS 1.2 support

### DIFF
--- a/GitHubAnalytics.psm1
+++ b/GitHubAnalytics.psm1
@@ -90,6 +90,8 @@ function Get-GitHubIssueForRepository
         {
             try
             {
+                # Force TLS 1.2
+                [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                 $jsonResult = Invoke-WebRequest $query
                 $issues = ConvertFrom-Json -InputObject $jsonResult.content
             }    
@@ -381,6 +383,8 @@ function Get-GitHubPullRequestForRepository
         {
             try
             {
+                # Force TLS 1.2
+                [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                 $jsonResult = Invoke-WebRequest $query
                 $pullRequests = ConvertFrom-Json -InputObject $jsonResult.content
             }    
@@ -640,6 +644,8 @@ function Get-GitHubRepositoryCollaborator
         {
             try
             {
+                # Force TLS 1.2
+                [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                 $jsonResult = Invoke-WebRequest $query
                 $collaborators = ConvertFrom-Json -InputObject $jsonResult.content
             }    
@@ -701,6 +707,8 @@ function Get-GitHubRepositoryContributor
         {
             try
             {
+                # Force TLS 1.2
+                [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                 $jsonResult = Invoke-WebRequest $query
                 $contributors = ConvertFrom-Json -InputObject $jsonResult.content
             }    
@@ -762,6 +770,8 @@ function Get-GitHubOrganizationMember
     {
         try
         {
+            # Force TLS 1.2
+            [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
             $jsonResult = Invoke-WebRequest $query
             $members = ConvertFrom-Json -InputObject $jsonResult.content
         }    
@@ -819,6 +829,8 @@ function Get-GitHubTeam
     {
         try
         {
+            # Force TLS 1.2
+            [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
             $jsonResult = Invoke-WebRequest $query
             $teams = ConvertFrom-Json -InputObject $jsonResult.content
         }    
@@ -891,6 +903,8 @@ function Get-GitHubTeamMember
     {
         try
         {
+            # Force TLS 1.2
+            [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
             $jsonResult = Invoke-WebRequest $query
             $members = ConvertFrom-Json -InputObject $jsonResult.content
         }    
@@ -949,6 +963,8 @@ function Get-GitHubOrganizationRepository
     {
         try
         {
+            # Force TLS 1.2
+            [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
             $jsonResult = Invoke-WebRequest $query
             $repositories = (ConvertFrom-Json -InputObject $jsonResult.content)
         }    
@@ -1010,6 +1026,8 @@ function Get-GitHubRepositoryBranch
     {
         try
         {
+            # Force TLS 1.2
+            [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
             $jsonResult = Invoke-WebRequest $query
             $branches = (ConvertFrom-Json -InputObject $jsonResult.content)
         }    
@@ -1091,7 +1109,9 @@ function Get-GitHubAuthenticatedUser
     {
         $query += "&access_token=$gitHubAccessToken"
     }
-        
+
+    # Force TLS 1.2    
+    [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
     $jsonResult = Invoke-WebRequest $query
     $user = ConvertFrom-Json -InputObject $jsonResult.content
 

--- a/GitHubLabels.psm1
+++ b/GitHubLabels.psm1
@@ -64,6 +64,8 @@ function Get-GitHubLabel
             {
                 try
                 {
+                    # Force TLS 1.2    
+                    [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                     $jsonResult = Invoke-WebRequest $query -Method Get -Headers $headers
                     $labels = ConvertFrom-Json -InputObject $jsonResult.content
                 }    
@@ -92,6 +94,8 @@ function Get-GitHubLabel
 
             try
             {
+                # Force TLS 1.2    
+                [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                 $jsonResult = Invoke-WebRequest $query -Method Get -Headers $headers
                 $label = ConvertFrom-Json -InputObject $jsonResult.content
             }    
@@ -145,6 +149,9 @@ function New-GitHubLabel
         $url = "$script:gitHubApiReposUrl/{0}/{1}/labels" -f $ownerName, $repositoryName
         
         Write-Host "Creating Label:" $labelName
+
+        # Force TLS 1.2    
+        [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
         $result = Invoke-WebRequest $url -Method Post -Body $data -Headers $headers
         
         if ($result.StatusCode -eq 201) 
@@ -188,6 +195,9 @@ function Remove-GitHubLabel
         $url = "$script:gitHubApiReposUrl/{0}/{1}/labels/{2}" -f $ownerName, $repositoryName, $labelName
         
         Write-Host "Deleting Label:" $labelName
+
+        # Force TLS 1.2    
+        [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
         $result = Invoke-WebRequest $url -Method Delete -Headers $headers
         
         if ($result.StatusCode -eq 204) 
@@ -240,6 +250,9 @@ function Update-GitHubLabel
         $url = "$script:gitHubApiReposUrl/{0}/{1}/labels/{2}" -f $ownerName, $repositoryName, $labelName
         
         Write-Host "Updating label '$labelName' to name '$newLabelName' and color '$labelColor'"
+
+        # Force TLS 1.2    
+        [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
         $result = Invoke-WebRequest $url -Method Patch -Body $data -Headers $headers
 
         if ($result.StatusCode -eq 200) 


### PR DESCRIPTION
Github [discontinued support for weak cryptographic standards](https://githubengineering.com/crypto-deprecation-notice/) last year. Therefore, TLS 1.2 should be enforced on all Rest API calls in the PowerShell modules.

This update also fixes [#33](https://github.com/PowerShell/PowerShellForGitHub/issues/33).