### PR TITLE
Temporarily disabling display of CI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # PowerShellForGitHub
-[![Build status](https://ci.appveyor.com/api/projects/status/t743qp9vfw9f2mq9?svg=true)](https://ci.appveyor.com/project/PowerShell/powershellforgithub)
 
 PowerShell wrapper for GitHub API.
 


### PR DESCRIPTION
Some of the secret teams that the Pester tests depend on
appear to no longer be valid (they were set up by the
previous module administrator many years ago).

Until this is resolved, removing the CI status from the
README in order to avoid potential end-user confusion on
the current status/quality of the module.