### PR TITLE
Improve robustness of `Get-NugetPackageDllPath` to file access issues

### DIFF
--- a/NugetTools.ps1
+++ b/NugetTools.ps1
@@ -198,7 +198,14 @@ function Test-AssemblyIsDesiredVersion
 
     $splitTargetVer = $DesiredVersion.Split('.')
 
-    $versionInfo = (Get-Item -Path $AssemblyPath).VersionInfo
+    $file = Get-Item -Path $AssemblyPath -ErrorVariable ev
+    if (($null -ne $ev) -and ($ev.Count -gt 0))
+    {
+        Write-Log "Problem accessing [$Path]: $($ev[0].Exception.Message)" -Level Warning
+        return $false
+    }
+
+    $versionInfo = $file.VersionInfo
     $splitSourceVer = @(
         $versionInfo.ProductMajorPart,
         $versionInfo.ProductMinorPart,
@@ -300,7 +307,7 @@ function Get-NugetPackageDllPath
 
     # First we'll check to see if the user has cached the assembly into the module's script directory
     $moduleAssembly = Join-Path -Path $PSScriptRoot -ChildPath $AssemblyName
-    if (Test-Path -Path $moduleAssembly -PathType Leaf)
+    if (Test-Path -Path $moduleAssembly -PathType Leaf -ErrorAction Ignore)
     {
         if (Test-AssemblyIsDesiredVersion -AssemblyPath $moduleAssembly -DesiredVersion $NugetPackageVersion)
         {
@@ -318,7 +325,7 @@ function Get-NugetPackageDllPath
     if (-not [System.String]::IsNullOrEmpty($alternateAssemblyPath))
     {
         $assemblyPath = Join-Path -Path $alternateAssemblyPath -ChildPath $AssemblyName
-        if (Test-Path -Path $assemblyPath -PathType Leaf)
+        if (Test-Path -Path $assemblyPath -PathType Leaf -ErrorAction Ignore)
         {
             if (Test-AssemblyIsDesiredVersion -AssemblyPath $assemblyPath -DesiredVersion $NugetPackageVersion)
             {
@@ -340,7 +347,7 @@ function Get-NugetPackageDllPath
     else
     {
         $cachedAssemblyPath = Join-Path -Path $(Join-Path $script:tempAssemblyCacheDir $AssemblyPackageTailDirectory) $AssemblyName
-        if (Test-Path -Path $cachedAssemblyPath -PathType Leaf)
+        if (Test-Path -Path $cachedAssemblyPath -PathType Leaf -ErrorAction Ignore)
         {
             if (Test-AssemblyIsDesiredVersion -AssemblyPath $cachedAssemblyPath -DesiredVersion $NugetPackageVersion)
             {
@@ -359,7 +366,7 @@ function Get-NugetPackageDllPath
     Get-NugetPackage -PackageName $NugetPackageName -Version $NugetPackageVersion -TargetPath $script:tempAssemblyCacheDir -NoStatus:$NoStatus
 
     $cachedAssemblyPath = Join-Path -Path $(Join-Path -Path $script:tempAssemblyCacheDir -ChildPath $AssemblyPackageTailDirectory) -ChildPath $AssemblyName
-    if (Test-Path -Path $cachedAssemblyPath -PathType Leaf)
+    if (Test-Path -Path $cachedAssemblyPath -PathType Leaf -ErrorAction Ignore)
     {
         Write-Log -Message @(
             "To avoid this download delay in the future, copy the following file:",


### PR DESCRIPTION
`Test-Path` will write to the error stream if there is a file access issue,
but still return back `$false`.  Within this method, we simply want to test
if the file exists -- not having access to the file is an equivalence case
for us and should be silent.

This updates `Test-Path` to use `-ErrorAction Ignore` to silence any potential
errors that we don't care about.

Additionally this updates `Test-AssemblyIsDesiredVersion` to also be robust
to file access issues.  If it has issues getting the file information, even
after getting passed the `Test-Path` in the parameter validation, we want to
gracefully return `$false` without undo error logging (we will write a
Warning log entry though for completeness).