### PR TITLE
Update logging to redact AccessToken if provided at commandline

### DIFF
--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -95,10 +95,6 @@ function Set-GitHubConfiguration
         Specify this switch to disable the hashing of potential PII data prior to submitting the
         data to telemetry (if telemetry hasn't been disabled via DisableTelemetry).
 
-    .PARAMETER DisableParameterLogging
-        Specify this switch to stop the module from logging every individual parameter value
-        when it logs a function call.
-
     .PARAMETER DisableSmarterObjects
         By deffault, this module will modify all objects returned by the API calls to update
         any properties that can be converted to objects (like strings for Date/Time's being
@@ -175,8 +171,6 @@ function Set-GitHubConfiguration
         [switch] $DisableLogging,
 
         [switch] $DisablePiiProtection,
-
-        [switch] $DisableParameterLogging,
 
         [switch] $DisableSmarterObjects,
 
@@ -263,7 +257,6 @@ function Get-GitHubConfiguration
             'DefaultOwnerName',
             'DefaultRepositoryName',
             'DisableLogging',
-            'DisableParameterLogging',
             'DisablePiiProtection',
             'DisableSmarterObjects',
             'DisableTelemetry',
@@ -593,7 +586,6 @@ function Import-GitHubConfiguration
         'applicationInsightsKey' = '66d83c52-3070-489b-886b-09860e05e78a'
         'assemblyPath' = [String]::Empty
         'disableLogging' = ([String]::IsNullOrEmpty($logPath))
-        'disableParameterLogging' = $false
         'disablePiiProtection' = $false
         'disableSmarterObjects' = $false
         'disableTelemetry' = $false

--- a/Telemetry.ps1
+++ b/Telemetry.ps1
@@ -396,7 +396,7 @@ function Set-TelemetryEvent
         return
     }
 
-    Write-InvocationLog -Invocation $MyInvocation
+    Write-InvocationLog -Invocation $MyInvocation -ExcludeParameter @('Properties', 'Metrics')
 
     try
     {
@@ -498,7 +498,7 @@ function Set-TelemetryException
         return
     }
 
-    Write-InvocationLog -Invocation $MyInvocation
+    Write-InvocationLog -Invocation $MyInvocation -ExcludeParameter @('Exception', 'Properties', 'NoFlush')
 
     try
     {


### PR DESCRIPTION
All API accessing methods allow users to provide an AccessToken to be used
for the duration of that API call.  The problem with that is that the
command is also logged by default, which means that the AccessToken value
might be logged in plain text to the log file.

To fix this, `Write-InvocationLog` has been modified in a few ways:
  * Can now redact the value of specified parameters, or exclude the parameter altogether.
  * `AccessToken` has been configured to _always_ be redacted, and
    `NoStatus` has been configured to _always_ be excluded (to avoid noise)
  * Instead of logging the originally invoked line, as well as the individual
    values of the parameters, this now logs a single line with a modified version
	of the invocation with the substitution of parameter values performed in-place.
  * The `DisableParameterLogging` configuation value has been removed, as we're no
    longer taking up additional verbose space (we're always logging a single line), and
	we have to process the parameters anyway to ensure that we're excluding/redacting
	the necessary parameters, meaning that we can't log the invoked line no matter what.