### PR TITLE
Add `LogRequestBody` configuration option to make development debugging easier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Looking for information on how to use this module?  Head on over to [README.md](
 *   [Coding Guidelines](#coding-guidelines)
 *   [Adding New Configuration Properties](#adding-new-configuration-properties)
 *   [Code Comments](#code-comments)
+*   [Debugging Tips](#debugging-tips)
 *   [Testing](#testing)
     *   [Installing Pester](#installing-pester)
     *   [Configuring Your Environment](#configuring-your-environment)
@@ -267,6 +268,17 @@ Good code comments should improve readability of the code, and make it much more
 That being said, some of the best code you can write is self-commenting.  By refactoring your code
 into small, well-named functions that concisely describe their purpose, it's possible to write
 code that reads clearly while requiring minimal comments to understand what it's doing.
+
+----------
+
+### Debugging Tips
+
+You may find it useful to configure the module to log the body of all REST requests during
+development of a new feature, to make it easier to see exactly what is being sent to GitHub.
+
+```powershell
+Set-GitHubConfiguration -LogRequestBody
+```
 
 ----------
 

--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -114,6 +114,10 @@ function Set-GitHubConfiguration
         log entry.  This can be useful if you have concurrent PowerShell sessions all logging
         to the same file, as it would then be possible to filter results based on ProcessId.
 
+    .PARAMETER LogRequestBody
+        If specified, the JSON body of the REST request will be logged to verbose output.
+        This can be helpful for debugging purposes.
+
     .PARAMETER LogTimeAsUtc
         If specified, all times logged will be logged as UTC instead of the local timezone.
 
@@ -179,6 +183,8 @@ function Set-GitHubConfiguration
         [string] $LogPath,
 
         [switch] $LogProcessId,
+
+        [switch] $LogRequestBody,
 
         [switch] $LogTimeAsUtc,
 
@@ -262,6 +268,7 @@ function Get-GitHubConfiguration
             'DisableTelemetry',
             'LogPath',
             'LogProcessId',
+            'LogRequestBody',
             'LogTimeAsUtc',
             'RetryDelaySeconds',
             'SuppressNoTokenWarning',
@@ -593,6 +600,7 @@ function Import-GitHubConfiguration
         'defaultRepositoryName' = [String]::Empty
         'logPath' = $logPath
         'logProcessId' = $false
+        'logRequestBody' = $false
         'logTimeAsUtc' = $false
         'retryDelaySeconds' = 30
         'suppressNoTokenWarning' = $false

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -200,7 +200,7 @@ function Invoke-GHRestMethod
                     $bodyAsBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
                     $params.Add("Body", $bodyAsBytes)
                     Write-Log -Message "Request includes a body." -Level Verbose
-                    if ($LogRequestBody)
+                    if (Get-GitHubConfiguration -Name LogRequestBody)
                     {
                         Write-Log -Message $Body -Level Verbose
                     }
@@ -243,7 +243,7 @@ function Invoke-GHRestMethod
                         $bodyAsBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
                         $params.Add("Body", $bodyAsBytes)
                         Write-Log -Message "Request includes a body." -Level Verbose
-                        if (Get-GitHubConfiguration -Name LogRequestBody)
+                        if ($LogRequestBody)
                         {
                             Write-Log -Message $Body -Level Verbose
                         }

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -202,7 +202,7 @@ function Invoke-GHRestMethod
                     Write-Log -Message "Request includes a body." -Level Verbose
                     if ($LogRequestBody)
                     {
-                        Write-Log -Message (ConvertTo-Json -InputObject $Body -Depth 20) -Level Verbose
+                        Write-Log -Message $Body -Level Verbose
                     }
                 }
 
@@ -245,7 +245,7 @@ function Invoke-GHRestMethod
                         Write-Log -Message "Request includes a body." -Level Verbose
                         if (Get-GitHubConfiguration -Name LogRequestBody)
                         {
-                            Write-Log -Message (ConvertTo-Json -InputObject $Body -Depth 20) -Level Verbose
+                            Write-Log -Message $Body -Level Verbose
                         }
                     }
 

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -200,6 +200,10 @@ function Invoke-GHRestMethod
                     $bodyAsBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
                     $params.Add("Body", $bodyAsBytes)
                     Write-Log -Message "Request includes a body." -Level Verbose
+                    if ($LogRequestBody)
+                    {
+                        Write-Log -Message (ConvertTo-Json -InputObject $Body -Depth 20) -Level Verbose
+                    }
                 }
 
                 [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
@@ -217,7 +221,7 @@ function Invoke-GHRestMethod
             if ($PSCmdlet.ShouldProcess($jobName, "Start-Job"))
             {
                 [scriptblock]$scriptBlock = {
-                    param($Url, $Method, $Headers, $Body, $ValidBodyContainingRequestMethods, $TimeoutSec, $ScriptRootPath)
+                    param($Url, $Method, $Headers, $Body, $ValidBodyContainingRequestMethods, $TimeoutSec, $LogRequestBody, $ScriptRootPath)
 
                     # We need to "dot invoke" Helpers.ps1 and GitHubConfiguration.ps1 within
                     # the context of this script block since we're running in a different
@@ -239,6 +243,10 @@ function Invoke-GHRestMethod
                         $bodyAsBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
                         $params.Add("Body", $bodyAsBytes)
                         Write-Log -Message "Request includes a body." -Level Verbose
+                        if (Get-GitHubConfiguration -Name LogRequestBody)
+                        {
+                            Write-Log -Message (ConvertTo-Json -InputObject $Body -Depth 20) -Level Verbose
+                        }
                     }
 
                     try
@@ -272,7 +280,7 @@ function Invoke-GHRestMethod
                     }
                 }
 
-                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body, $ValidBodyContainingRequestMethods, (Get-GitHubConfiguration -Name WebRequestTimeoutSec), $PSScriptRoot)
+                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body, $ValidBodyContainingRequestMethods, (Get-GitHubConfiguration -Name WebRequestTimeoutSec), (Get-GitHubConfiguration -Name LogRequestBody), $PSScriptRoot)
 
                 if ($PSCmdlet.ShouldProcess($jobName, "Wait-JobWithAnimation"))
                 {

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -280,7 +280,15 @@ function Invoke-GHRestMethod
                     }
                 }
 
-                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body, $ValidBodyContainingRequestMethods, (Get-GitHubConfiguration -Name WebRequestTimeoutSec), (Get-GitHubConfiguration -Name LogRequestBody), $PSScriptRoot)
+                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @(
+                    $url,
+                    $Method,
+                    $headers,
+                    $Body,
+                    $ValidBodyContainingRequestMethods,
+                    (Get-GitHubConfiguration -Name WebRequestTimeoutSec),
+                    (Get-GitHubConfiguration -Name LogRequestBody),
+                    $PSScriptRoot)
 
                 if ($PSCmdlet.ShouldProcess($jobName, "Wait-JobWithAnimation"))
                 {


### PR DESCRIPTION
If enabled, the JSON-serialized version of the body of any REST request will
be written to verbose output, so that you can see exactly what is being sent
to GitHub.