### PR TITLE
Issue param in Get-GitHubIssue will always be set to 0

### DIFF
--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -192,7 +192,7 @@ function Get-GitHubIssue
     {
         $uriFragment = "/repos/$OwnerName/$RepositoryName/issues"
         $description = "Getting issues for $RepositoryName"
-        if (-not [String]::IsNullOrEmpty($Issue))
+        if ($PSBoundParameters.ContainsKey('Issue'))
         {
             $uriFragment = $uriFragment + "/$Issue"
             $description = "Getting issue $Issue for $RepositoryName"


### PR DESCRIPTION
Since we changed the type of issue from string to int, the int will initialize at 0 and will fail our null check. This makes the code think that the Issue Param is always supplied. We should use $PSBoundParameters.ContainsKey to check this instead. This will fix issue #72.