### PR TITLE
Fix issue preventing labels from being updated when updating Issue

### DIFF
--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -640,7 +640,7 @@ function Update-GitHubIssue
     if ($PSBoundParameters.ContainsKey('Title')) { $hashBody['title'] = $Title }
     if ($PSBoundParameters.ContainsKey('Body')) { $hashBody['body'] = $Body }
     if ($PSBoundParameters.ContainsKey('Assignee')) { $hashBody['assignees'] = @($Assignee) }
-    if ($PSBoundParameters.ContainsKey('Label')) { $hashBody['label'] = @($Label) }
+    if ($PSBoundParameters.ContainsKey('Label')) { $hashBody['labels'] = @($Label) }
     if ($PSBoundParameters.ContainsKey('State')) { $hashBody['state'] = $State }
     if ($PSBoundParameters.ContainsKey('Milestone'))
     {

--- a/Tests/GitHubLabels.tests.ps1
+++ b/Tests/GitHubLabels.tests.ps1
@@ -378,6 +378,13 @@ try
                 $labelIssues.Count | Should be $defaultLabels.Count
             }
 
+            $updatedIssueLabels = @($labelsToAdd[0])
+            $updatedIssue = Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -Label $updatedIssueLabels
+
+            It 'Should have 1 label after updating the issue' {
+                $updatedIssue.labels.Count | Should be $updatedIssueLabels.Count
+            }
+
             $null = Remove-GitHubRepository -OwnerName $ownerName -RepositoryName $repositoryName
         }
     }


### PR DESCRIPTION
Similar to #76, `Update-GitHubIssue` was passing in the provided labels as `label` instead of `labels` in the request body.

This fixes the issue and also adds a UT to catch that scenario.