### PR TITLE
Fix all string parameters to be CamelCased and avoid abbreviation

### DIFF
--- a/GitHubAnalytics.ps1
+++ b/GitHubAnalytics.ps1
@@ -31,7 +31,7 @@ function Group-GitHubIssue
         $issues = @()
         $issues += Get-GitHubIssue -Uri 'https://github.com/powershell/xpsdesiredstateconfiguration'
         $issues += Get-GitHubIssue -Uri 'https://github.com/powershell/xactivedirectory'
-        $issues | Group-GitHubIssue -Weeks 12 -DateType closed
+        $issues | Group-GitHubIssue -Weeks 12 -DateType Closed
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -51,8 +51,8 @@ function Group-GitHubIssue
         [int] $Weeks,
 
         [Parameter(ParameterSetName='Weekly')]
-        [ValidateSet('created', 'closed')]
-        [string] $DateType = 'created'
+        [ValidateSet('Created', 'Closed')]
+        [string] $DateType = 'Created'
     )
 
     Write-InvocationLog
@@ -66,8 +66,8 @@ function Group-GitHubIssue
         foreach ($week in $weekDates)
         {
             $filteredIssues = @($Issue | Where-Object {
-                (($DateType -eq 'created') -and ($_.created_at -ge $week) -and ($_.created_at -le $endOfWeek)) -or
-                (($DateType -eq 'closed') -and ($_.closed_at -ge $week) -and ($_.closed_at -le $endOfWeek))
+                (($DateType -eq 'Created') -and ($_.created_at -ge $week) -and ($_.created_at -le $endOfWeek)) -or
+                (($DateType -eq 'Closed') -and ($_.closed_at -ge $week) -and ($_.closed_at -le $endOfWeek))
             })
 
             $endOfWeek = $week
@@ -124,7 +124,7 @@ function Group-GitHubPullRequest
         $pullRequests = @()
         $pullRequests += Get-GitHubPullRequest -Uri 'https://github.com/powershell/xpsdesiredstateconfiguration'
         $pullRequests += Get-GitHubPullRequest -Uri 'https://github.com/powershell/xactivedirectory'
-        $pullRequests | Group-GitHubPullRequest -Weeks 12 -DateType closed
+        $pullRequests | Group-GitHubPullRequest -Weeks 12 -DateType Closed
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -144,8 +144,8 @@ function Group-GitHubPullRequest
         [int] $Weeks,
 
         [Parameter(ParameterSetName='Weekly')]
-        [ValidateSet('created', 'merged')]
-        [string] $DateType = 'created'
+        [ValidateSet('Created', 'Merged')]
+        [string] $DateType = 'Created'
     )
 
     Write-InvocationLog
@@ -159,8 +159,8 @@ function Group-GitHubPullRequest
         foreach ($week in $weekDates)
         {
             $filteredPullRequests = @($PullRequest | Where-Object {
-                (($DateType -eq 'created') -and ($_.created_at -ge $week) -and ($_.created_at -le $endOfWeek)) -or
-                (($DateType -eq 'merged') -and ($_.merged_at -ge $week) -and ($_.merged_at -le $endOfWeek))
+                (($DateType -eq 'Created') -and ($_.created_at -ge $week) -and ($_.created_at -le $endOfWeek)) -or
+                (($DateType -eq 'Merged') -and ($_.merged_at -ge $week) -and ($_.merged_at -le $endOfWeek))
             })
 
             $endOfWeek = $week

--- a/GitHubComments.ps1
+++ b/GitHubComments.ps1
@@ -96,16 +96,16 @@ function Get-GitHubComment
 
         [Parameter(ParameterSetName='RepositoryUri')]
         [Parameter(ParameterSetName='RepositoryElements')]
-        [ValidateSet('created', 'updated')]
+        [ValidateSet('Created', 'Updated')]
         [string] $Sort,
 
         [Parameter(ParameterSetName='RepositoryUri')]
         [Parameter(ParameterSetName='RepositoryElements')]
-        [ValidateSet('asc', 'desc')]
+        [ValidateSet('Ascending', 'Descending')]
         [string] $Direction,
 
-        [ValidateSet('raw', 'text', 'html', 'full')]
-        [string] $MediaType ='raw',
+        [ValidateSet('Raw', 'Text', 'Html', 'Full')]
+        [string] $MediaType ='Raw',
 
         [string] $AccessToken,
 
@@ -120,9 +120,10 @@ function Get-GitHubComment
     $uriFragment = [String]::Empty
     $description = [String]::Empty
 
+    $sinceFormattedTime = [String]::Empty
     if ($null -ne $Since)
     {
-        $SinceFormattedTime = $Since.ToUniversalTime().ToString('o')
+        $sinceFormattedTime = $Since.ToUniversalTime().ToString('o')
     }
 
     $telemetryProperties = @{
@@ -143,7 +144,7 @@ function Get-GitHubComment
 
         if ($PSBoundParameters.ContainsKey('Since'))
         {
-            $uriFragment += "since=$SinceFormattedTime"
+            $uriFragment += "since=$sinceFormattedTime"
         }
 
         $description = "Getting comments for issue $Issue in $RepositoryName"
@@ -154,17 +155,22 @@ function Get-GitHubComment
 
         if ($PSBoundParameters.ContainsKey('Sort'))
         {
-            $getParams += "sort=$Sort"
+            $getParams += "sort=$($Sort.ToLower())"
         }
 
         if ($PSBoundParameters.ContainsKey('Direction'))
         {
-            $getParams += "direction=$Direction"
+            $directionConverter = @{
+                'Ascending' = 'asc'
+                'Descending' = 'desc'
+            }
+
+            $getParams += "direction=$($directionConverter[$Direction])"
         }
 
         if ($PSBoundParameters.ContainsKey('Since'))
         {
-            $getParams += "since=$SinceFormattedTime"
+            $getParams += "since=$sinceFormattedTime"
         }
 
         $uriFragment = "repos/$OwnerName/$RepositoryName/issues/comments`?" +  ($getParams -join '&')
@@ -256,8 +262,8 @@ function New-GitHubComment
         [Parameter(Mandatory)]
         [string] $Body,
 
-        [ValidateSet('raw', 'text', 'html', 'full')]
-        [string] $MediaType ='raw',
+        [ValidateSet('Raw', 'Text', 'Html', 'Full')]
+        [string] $MediaType ='Raw',
 
         [string] $AccessToken,
 
@@ -367,8 +373,8 @@ function Set-GitHubComment
         [Parameter(Mandatory)]
         [string] $Body,
 
-        [ValidateSet('raw', 'text', 'html', 'full')]
-        [string] $MediaType ='raw',
+        [ValidateSet('Raw', 'Text', 'Html', 'Full')]
+        [string] $MediaType ='Raw',
 
         [string] $AccessToken,
 
@@ -512,19 +518,19 @@ function Get-CommentAcceptHeader
         full - Return raw, text and HTML representations. Response will include body, body_text, and body_html.
 
     .EXAMPLE
-        Get-CommentAcceptHeader -MediaType raw
+        Get-CommentAcceptHeader -MediaType Raw
 
         Returns a formatted AcceptHeader for v3 of the response object
 #>
     [CmdletBinding()]
     param(
-        [ValidateSet('raw', 'text', 'html', 'full')]
-        [string] $MediaType ='raw'
+        [ValidateSet('Raw', 'Text', 'Html', 'Full')]
+        [string] $MediaType ='Raw'
     )
 
     $acceptHeaders = @(
         'application/vnd.github.squirrel-girl-preview',
-        "application/vnd.github.$mediaTypeVersion.$MediaType+json")
+        "application/vnd.github.$mediaTypeVersion.$($MediaType.ToLower())+json")
 
     return ($acceptHeaders -join ',')
 }

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -12,7 +12,7 @@
      Set-Variable -Scope Script -Option ReadOnly -Name $_.Key -Value $_.Value
  }
 
-Set-Variable -Scope Script -Option ReadOnly -Name ValidBodyContainingRequestMethods -Value ('post', 'patch', 'put', 'delete')
+Set-Variable -Scope Script -Option ReadOnly -Name ValidBodyContainingRequestMethods -Value ('Post', 'Patch', 'Put', 'Delete')
 
 function Invoke-GHRestMethod
 {
@@ -102,7 +102,7 @@ function Invoke-GHRestMethod
         [string] $UriFragment,
 
         [Parameter(Mandatory)]
-        [ValidateSet('delete', 'get', 'post', 'patch', 'put')]
+        [ValidateSet('Delete', 'Get', 'Post', 'Patch', 'Put')]
         [string] $Method,
 
         [string] $Description,
@@ -208,7 +208,7 @@ function Invoke-GHRestMethod
 
                 [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                 $result = Invoke-WebRequest @params
-                if ($Method -eq 'delete')
+                if ($Method -eq 'Delete')
                 {
                     Write-Log -Message "Successfully removed." -Level Verbose
                 }
@@ -306,7 +306,7 @@ function Invoke-GHRestMethod
                 throw $remoteErrors[0].Exception
             }
 
-            if ($Method -eq 'delete')
+            if ($Method -eq 'Delete')
             {
                 Write-Log -Message "Successfully removed." -Level Verbose
             }

--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -98,12 +98,12 @@ function Get-GitHubIssue
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State open
+        Get-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State Open
 
         Gets all the currently open issues in the PowerShell\PowerShellForGitHub repository.
 
     .EXAMPLE
-        Get-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State all -Assignee Octocat
+        Get-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State All -Assignee Octocat
 
         Gets every issue in the PowerShell\PowerShellForGitHub repository that is assigned to Octocat.
 #>
@@ -125,35 +125,35 @@ function Get-GitHubIssue
 
         [string] $OrganizationName,
 
-        [ValidateSet('all', 'ownedAndMember')]
-        [string] $RepositoryType = 'all',
+        [ValidateSet('All', 'OwnedAndMember')]
+        [string] $RepositoryType = 'All',
 
         [int] $Issue,
 
         [switch] $IgnorePullRequests,
 
-        [ValidateSet('assigned', 'created', 'mentioned', 'subscribed', 'all')]
-        [string] $Filter = 'assigned',
+        [ValidateSet('Assigned', 'Created', 'Mentioned', 'Subscribed', 'All')]
+        [string] $Filter = 'Assigned',
 
-        [ValidateSet('open', 'closed', 'all')]
-        [string] $State = 'open',
+        [ValidateSet('Open', 'Closed', 'All')]
+        [string] $State = 'Open',
 
         [string[]] $Label,
 
-        [ValidateSet('created', 'updated', 'comments')]
-        [string] $Sort = 'created',
+        [ValidateSet('Created', 'Updated', 'Comments')]
+        [string] $Sort = 'Created',
 
-        [ValidateSet('asc', 'desc')]
-        [string] $Direction = 'desc',
+        [ValidateSet('Ascending', 'Descending')]
+        [string] $Direction = 'Descending',
 
         [DateTime] $Since,
 
-        [ValidateSet('specific', 'all', 'none')]
+        [ValidateSet('Specific', 'All', 'None')]
         [string] $MilestoneType,
 
         [string] $Milestone,
 
-        [ValidateSet('specific', 'all', 'none')]
+        [ValidateSet('Specific', 'All', 'None')]
         [string] $AssigneeType,
 
         [string] $Assignee,
@@ -203,12 +203,12 @@ function Get-GitHubIssue
         $uriFragment = "/orgs/$OrganizationName/issues"
         $description = "Getting issues for $OrganizationName"
     }
-    elseif ($RepositoryType -eq 'all')
+    elseif ($RepositoryType -eq 'All')
     {
         $uriFragment = "/issues"
         $description = "Getting issues across owned, member and org repositories"
     }
-    elseif ($RepositoryType -eq 'ownedAndMember')
+    elseif ($RepositoryType -eq 'OwnedAndMember')
     {
         $uriFragment = "/user/issues"
         $description = "Getting issues across owned and member repositories"
@@ -218,11 +218,16 @@ function Get-GitHubIssue
         throw "Parameter set not supported."
     }
 
+    $directionConverter = @{
+        'Ascending' = 'asc'
+        'Descending' = 'desc'
+    }
+
     $getParams = @(
-        "filter=$Filter",
-        "state=$State",
-        "sort=$Sort",
-        "direction=$Direction"
+        "filter=$($Filter.ToLower())",
+        "state=$($State.ToLower())",
+        "sort=$($Sort.ToLower())",
+        "direction=$($directionConverter[$Direction])"
     )
 
     if ($PSBoundParameters.ContainsKey('Label'))
@@ -242,11 +247,11 @@ function Get-GitHubIssue
 
     if ($PSBoundParameters.ContainsKey('MilestoneType'))
     {
-        if ($MilestoneType -eq 'all')
+        if ($MilestoneType -eq 'All')
         {
             $getParams += 'mentioned=*'
         }
-        elseif ($MilestoneType -eq 'none')
+        elseif ($MilestoneType -eq 'None')
         {
             $getParams += 'mentioned=none'
         }
@@ -585,7 +590,7 @@ function Update-GitHubIssue
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Update-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 4 -Title 'Test Issue' -State closed
+        Update-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 4 -Title 'Test Issue' -State Closed
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -616,7 +621,7 @@ function Update-GitHubIssue
 
         [string[]] $Label,
 
-        [ValidateSet('open', 'closed')]
+        [ValidateSet('Open', 'Closed')]
         [string] $State,
 
         [string] $AccessToken,
@@ -641,7 +646,7 @@ function Update-GitHubIssue
     if ($PSBoundParameters.ContainsKey('Body')) { $hashBody['body'] = $Body }
     if ($PSBoundParameters.ContainsKey('Assignee')) { $hashBody['assignees'] = @($Assignee) }
     if ($PSBoundParameters.ContainsKey('Label')) { $hashBody['labels'] = @($Label) }
-    if ($PSBoundParameters.ContainsKey('State')) { $hashBody['state'] = $State }
+    if ($PSBoundParameters.ContainsKey('State')) { $hashBody['state'] = $State.ToLower() }
     if ($PSBoundParameters.ContainsKey('Milestone'))
     {
         $hashBody['milestone'] = $Milestone
@@ -707,7 +712,7 @@ function Lock-GitHubIssue
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Lock-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 4 -Title 'Test Issue' -Reason spam
+        Lock-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 4 -Title 'Test Issue' -Reason Spam
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -728,7 +733,7 @@ function Lock-GitHubIssue
         [Parameter(Mandatory)]
         [int] $Issue,
 
-        [ValidateSet('off-topic', 'too heated', 'resolved', 'spam')]
+        [ValidateSet('OffTopic', 'TooHeated', 'Resolved', 'Spam')]
         [string] $Reason,
 
         [string] $AccessToken,
@@ -753,8 +758,15 @@ function Lock-GitHubIssue
 
     if ($PSBoundParameters.ContainsKey('Reason'))
     {
+        $reasonConverter = @{
+            'OffTopic' = 'off-topic'
+            'TooHeated' = 'too heated'
+            'Resolved' = 'resolved'
+            'Spam' = 'spam'
+        }
+
         $telemetryProperties['Reason'] = $Reason
-        $hashBody['active_lock_reason'] = $Reason
+        $hashBody['active_lock_reason'] = $reasonConverter[$Reason]
     }
 
     $params = @{

--- a/GitHubMilestones.ps1
+++ b/GitHubMilestones.ps1
@@ -118,26 +118,22 @@ function Get-GitHubMilestone
 
         if ($PSBoundParameters.ContainsKey('Sort'))
         {
-            if ($Sort -eq "Completeness")
-            {
-                $getParams += "sort=completeness"
+            $sortConverter = @{
+                'Completeness' = 'completeness'
+                'DueOn' = 'due_on'
             }
-            elseif ($Sort -eq "DueOn")
-            {
-                $getParams += "sort=due_on"
-            }
+
+            $getParams += "sort=$($sortConverter[$Sort])"
         }
 
         if ($PSBoundParameters.ContainsKey('Direction'))
         {
-            if ($Direction -eq "Ascending")
-            {
-                $getParams += "direction=asc"
+            $directionConverter = @{
+                'Ascending' = 'asc'
+                'Descending' = 'desc'
             }
-            elseif ($Direction -eq "Descending")
-            {
-                $getParams += "direction=desc"
-            }
+
+            $getParams += "direction=$($directionConverter[$Direction])"
         }
 
         if ($PSBoundParameters.ContainsKey('State'))

--- a/GitHubMiscellaneous.ps1
+++ b/GitHubMiscellaneous.ps1
@@ -90,9 +90,9 @@ function ConvertFrom-Markdown
     .PARAMETER Mode
         The rendering mode for the Markdown content.
 
-        markdown - Renders Content in plain Markdown, just like README.md files are rendered
+        Markdown - Renders Content in plain Markdown, just like README.md files are rendered
 
-        gfm (GitHub Flavored Markdown) - Creates links for user mentions as well as references to
+        GitHubFlavoredMarkdown - Creates links for user mentions as well as references to
         SHA-1 hashes, issues, and pull requests.
 
     .PARAMETER Context
@@ -113,7 +113,9 @@ function ConvertFrom-Markdown
         [String] The HTML version of the Markdown content.
 
     .EXAMPLE
-        Get-GitHubRateLimit
+        ConvertFrom-Markdown -Content '**Bolded Text**' -Mode Markdown
+
+        Returns back '<p><strong>Bolded Text</strong></p>'
 #>
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
@@ -125,7 +127,7 @@ function ConvertFrom-Markdown
         [ValidateScript({if ([System.Text.Encoding]::UTF8.GetBytes($_).Count -lt 400000) { $true } else { throw "Content must be less than 400 KB." }})]
         [string] $Content,
 
-        [ValidateSet('markdown', 'gfm')]
+        [ValidateSet('Markdown', 'GitHubFlavoredMarkdown')]
         [string] $Mode = 'markdown',
 
         [string] $Context,
@@ -141,9 +143,14 @@ function ConvertFrom-Markdown
         'Mode' = $Mode
     }
 
+    $modeConverter = @{
+        'Markdown' = 'markdown'
+        'GitHubFlavoredMarkdown' = 'gfm'
+    }
+
     $hashBody = @{
         'text' = $Content
-        'mode' = $Mode
+        'mode' = $modeConverter[$Mode]
     }
 
     if (-not [String]::IsNullOrEmpty($Context)) { $hashBody['context'] = $Context }

--- a/GitHubPullRequests.ps1
+++ b/GitHubPullRequests.ps1
@@ -65,7 +65,7 @@ function Get-GitHubPullRequest
         $pullRequests = Get-GitHubPullRequest -Uri 'https://github.com/PowerShell/PowerShellForGitHub'
 
     .EXAMPLE
-        $pullRequests = Get-GitHubPullRequest -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State closed
+        $pullRequests = Get-GitHubPullRequest -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State Closed
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -85,18 +85,18 @@ function Get-GitHubPullRequest
 
         [string] $PullRequest,
 
-        [ValidateSet('open', 'closed', 'all')]
-        [string] $State = 'open',
+        [ValidateSet('Open', 'Closed', 'All')]
+        [string] $State = 'Open',
 
         [string] $Head,
 
         [string] $Base,
 
-        [ValidateSet('created', 'updated', 'popularity', 'long-running')]
-        [string] $Sort = 'created',
+        [ValidateSet('Created', 'Updated', 'Popularity', 'LongRunning')]
+        [string] $Sort = 'Created',
 
-        [ValidateSet('asc', 'desc')]
-        [string] $Direction = 'desc',
+        [ValidateSet('Ascending', 'Descending')]
+        [string] $Direction = 'Descending',
 
         [string] $AccessToken,
 
@@ -123,10 +123,22 @@ function Get-GitHubPullRequest
         $description = "Getting pull request $PullRequest for $RepositoryName"
     }
 
+    $sortConverter = @{
+        'Created' = 'created'
+        'Updated' = 'updated'
+        'Popularity' = 'popularity'
+        'LongRunning' = 'long-running'
+    }
+
+    $directionConverter = @{
+        'Ascending' = 'asc'
+        'Descending' = 'desc'
+    }
+
     $getParams = @(
-        "state=$State",
-        "sort=$Sort",
-        "direction=$Direction"
+        "state=$($State.ToLower())",
+        "sort=$($sortConverter[$Sort])",
+        "direction=$($directionConverter[$Direction])"
     )
 
     if ($PSBoundParameters.ContainsKey('Head'))

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -368,18 +368,18 @@ function Get-GitHubRepository
         [Parameter(ParameterSetName='Organization')]
         [string] $OrganizationName,
 
-        [ValidateSet('all', 'public', 'private')]
+        [ValidateSet('All', 'Public', 'Private')]
         [string] $Visibility,
 
         [string[]] $Affiliation,
 
-        [ValidateSet('all', 'owner', 'public', 'private', 'member', 'forks', 'sources')]
+        [ValidateSet('All', 'Owner', 'Public', 'Private', 'Member', 'Forks', 'Sources')]
         [string] $Type,
 
-        [ValidateSet('created', 'updated', 'pushed', 'full_name')]
+        [ValidateSet('Created', 'Updated', 'Pushed', 'FullName')]
         [string] $Sort,
 
-        [ValidateSet('asc', 'desc')]
+        [ValidateSet('Ascending', 'Descending')]
         [string] $Direction,
 
         [switch] $GetAllPublicRepositories,
@@ -427,11 +427,23 @@ function Get-GitHubRepository
         $description = "Getting repos for $OwnerName"
     }
 
+    $sortConverter = @{
+        'Created' = 'created'
+        'Updated' = 'updated'
+        'Pushed' = 'pushed'
+        'FullName' = 'full_name'
+    }
+
+    $directionConverter = @{
+        'Ascending' = 'asc'
+        'Descending' = 'desc'
+    }
+
     $getParams = @()
-    if ($PSBoundParameters.ContainsKey('Visibility')) { $getParams += "visibility=$Visibility" }
-    if ($PSBoundParameters.ContainsKey('Sort')) { $getParams += "sort=$Sort" }
-    if ($PSBoundParameters.ContainsKey('Type')) { $getParams += "type=$Type" }
-    if ($PSBoundParameters.ContainsKey('Direction')) { $getParams += "direction=$Direction" }
+    if ($PSBoundParameters.ContainsKey('Visibility')) { $getParams += "visibility=$($Visibility.ToLower())" }
+    if ($PSBoundParameters.ContainsKey('Sort')) { $getParams += "sort=$($sortConverter[$Sort])" }
+    if ($PSBoundParameters.ContainsKey('Type')) { $getParams += "type=$($Type.ToLower())" }
+    if ($PSBoundParameters.ContainsKey('Direction')) { $getParams += "direction=$($directionConverter[$Direction])" }
     if ($PSBoundParameters.ContainsKey('Affiliation') -and $Affiliation.Count -gt 0)
     {
         $getParams += "affiliation=$($Affiliation -join ',')"
@@ -523,13 +535,6 @@ function Update-GitHubRepository
         with no commandline status update.  When not specified, those commands run in
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
-
-    .NOTES
-        It's possible that the ValidateSet values for GitIgnoreTemplate and LicenseTemplate
-        can get out of sync if some are added or removed after this module is published.
-        It was considered to make these free-form entries, but the most likely scenario is
-        that entries won't be added/removed often, making it more convenient to the end-user
-        to have the finite set of options available directly via the ValidateSets.
 
     .EXAMPLE
         Update-GitHubRepository -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Description 'The best way to automate your GitHub interactions'
@@ -1241,13 +1246,6 @@ function Move-GitHubRepositoryOwnership
         with no commandline status update.  When not specified, those commands run in
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
-
-    .NOTES
-        It's possible that the ValidateSet values for GitIgnoreTemplate and LicenseTemplate
-        can get out of sync if some are added or removed after this module is published.
-        It was considered to make these free-form entries, but the most likely scenario is
-        that entries won't be added/removed often, making it more convenient to the end-user
-        to have the finite set of options available directly via the ValidateSets.
 
     .EXAMPLE
         Move-GitHubRepositoryOwnership -OwnerName PowerShell -RepositoryName PowerShellForGitHub -NewOwnerName OctoCat

--- a/GitHubRepositoryForks.ps1
+++ b/GitHubRepositoryForks.ps1
@@ -59,8 +59,8 @@ function Get-GitHubRepositoryFork
             ParameterSetName='Uri')]
         [string] $Uri,
 
-        [ValidateSet('newest', 'oldest', 'stargazers')]
-        [string] $Sort = 'newest',
+        [ValidateSet('Newest', 'Oldest', 'Stargazers')]
+        [string] $Sort = 'Newest',
 
         [string] $AccessToken,
 
@@ -80,7 +80,7 @@ function Get-GitHubRepositoryFork
     }
 
     $getParams = @(
-        "sort=$Sort"
+        "sort=$($Sort.ToLower())"
     )
 
     $params = @{

--- a/GitHubRepositoryTraffic.ps1
+++ b/GitHubRepositoryTraffic.ps1
@@ -228,8 +228,8 @@ function Get-GitHubViewTraffic
             ParameterSetName='Uri')]
         [string] $Uri,
 
-        [ValidateSet('day', 'week')]
-        [string] $Per = 'day',
+        [ValidateSet('Day', 'Week')]
+        [string] $Per = 'Day',
 
         [string] $AccessToken,
 
@@ -249,7 +249,7 @@ function Get-GitHubViewTraffic
     }
 
     $params = @{
-        'UriFragment' = "repos/$OwnerName/$RepositoryName/traffic/views`?per=$Per"
+        'UriFragment' = "repos/$OwnerName/$RepositoryName/traffic/views`?per=$($Per.ToLower())"
         'Method' = 'Get'
         'Description' =  "Getting views for $RepositoryName"
         'AccessToken' = $AccessToken
@@ -320,8 +320,8 @@ function Get-GitHubCloneTraffic
             ParameterSetName='Uri')]
         [string] $Uri,
 
-        [ValidateSet('day', 'week')]
-        [string] $Per = 'day',
+        [ValidateSet('Day', 'Week')]
+        [string] $Per = 'Day',
 
         [string] $AccessToken,
 
@@ -341,7 +341,7 @@ function Get-GitHubCloneTraffic
     }
 
     $params = @{
-        'UriFragment' = "repos/$OwnerName/$RepositoryName/traffic/clones`?per=$Per"
+        'UriFragment' = "repos/$OwnerName/$RepositoryName/traffic/clones`?per=$($Per.ToLower())"
         'Method' = 'Get'
         'Description' =  "Getting number of clones for $RepositoryName"
         'AccessToken' = $AccessToken

--- a/GitHubUsers.ps1
+++ b/GitHubUsers.ps1
@@ -125,7 +125,7 @@ function Get-GitHubUserContextualInformation
         Get-GitHubUserContextualInformation -User octocat
 
     .EXAMPLE
-        Get-GitHubUserContextualInformation -User octocat -Subject repository -SubjectId 1300192
+        Get-GitHubUserContextualInformation -User octocat -Subject Repository -SubjectId 1300192
 #>
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
@@ -133,7 +133,7 @@ function Get-GitHubUserContextualInformation
         [Parameter(Mandatory)]
         [string] $User,
 
-        [ValidateSet('organization', 'repository', 'issue', 'pull_request')]
+        [ValidateSet('Organization', 'Repository', 'Issue', 'PullRequest')]
         [string] $Subject,
 
         [string] $SubjectId,
@@ -157,7 +157,14 @@ function Get-GitHubUserContextualInformation
             throw $message
         }
 
-        $getParams += "subject_type=$Subject"
+        $subjectConverter = @{
+            'Organization' = 'organization'
+            'Repository' = 'repository'
+            'Issue' = 'issue'
+            'PullRequest' = 'pull_request'
+        }
+
+        $getParams += "subject_type=$($subjectConverter[$Subject])"
         $getParams += "subject_id=$SubjectId"
     }
 

--- a/Tests/GitHubAnalytics.tests.ps1
+++ b/Tests/GitHubAnalytics.tests.ps1
@@ -97,15 +97,15 @@ try
                 Start-Sleep -Seconds 5
             }
 
-            $newIssues[0] = Update-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[0].number -State closed
-            $newIssues[-1] = Update-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[-1].number -State closed
+            $newIssues[0] = Update-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[0].number -State Closed
+            $newIssues[-1] = Update-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[-1].number -State Closed
 
             $issues = Get-GitHubIssue -Uri $repo.svn_url
             It 'Should return only open issues' {
                 @($issues).Count | Should be 2
             }
 
-            $issues = Get-GitHubIssue -Uri $repo.svn_url -State all
+            $issues = Get-GitHubIssue -Uri $repo.svn_url -State All
             It 'Should return all issues' {
                 @($issues).Count | Should be 4
             }
@@ -119,7 +119,7 @@ try
             }
 
             $createdDate = Get-Date -Date $newIssues[1].created_at
-            $issues = Get-GitHubIssue -Uri $repo.svn_url -State all | Where-Object { ($_.created_at -ge $createdDate) -and ($_.state -eq 'closed') }
+            $issues = Get-GitHubIssue -Uri $repo.svn_url -State All | Where-Object { ($_.created_at -ge $createdDate) -and ($_.state -eq 'closed') }
 
             It 'Able to filter based on date and state' {
                 @($issues).Count | Should be 1
@@ -175,7 +175,7 @@ try
     #     Context 'When state and time range specified' {
     #         $mergedStartDate = Get-Date -Date '2016-04-10'
     #         $mergedEndDate = Get-Date -Date '2016-05-07'
-    #         $pullRequests = Get-GitHubPullRequest -Uri $script:repositoryUrl -State closed |
+    #         $pullRequests = Get-GitHubPullRequest -Uri $script:repositoryUrl -State Closed |
     #             Where-Object { ($_.merged_at -ge $mergedStartDate) -and ($_.merged_at -le $mergedEndDate) }
 
     #         It 'Should return expected number of PRs' {
@@ -222,7 +222,7 @@ try
     #                 }) }
 
     #         $pullRequestCounts = $pullRequestCounts | Sort-Object -Property Count -Descending
-    #         $pullRequests = Get-GitHubTopPullRequestRepository -Uri @($script:repositoryUrl, $script:repositoryUrl2) -State closed -MergedOnOrAfter
+    #         $pullRequests = Get-GitHubTopPullRequestRepository -Uri @($script:repositoryUrl, $script:repositoryUrl2) -State Closed -MergedOnOrAfter
 
     #         It 'Should return expected number of pull requests for each repository' {
     #             @($pullRequests[0].Count) | Should be 3

--- a/Tests/GitHubEvents.tests.ps1
+++ b/Tests/GitHubEvents.tests.ps1
@@ -93,7 +93,7 @@ try
             }
 
             $issue = New-GithubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Title "New Issue"
-            Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State closed
+            Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State Closed
 
             Context 'For getting events from a repository' {
                 $events = @(Get-GitHubEvent -OwnerName $ownerName -RepositoryName $repositoryName)
@@ -120,8 +120,8 @@ try
             }
 
             Context 'For getting events from an issue' {
-                Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State closed
-                Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State open
+                Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State Closed
+                Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State Open
                 $events = @(Get-GitHubEvent -OwnerName $ownerName -RepositoryName $repositoryName)
 
                 It 'Should have two events from closing and opening the issue' {
@@ -136,8 +136,8 @@ try
             $repositoryName = [Guid]::NewGuid()
             $null = New-GitHubRepository -RepositoryName $repositoryName
             $issue = New-GithubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Title "New Issue"
-            Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State closed
-            Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State open
+            Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State Closed
+            Update-GitHubIssue -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number -State Open
             $events = @(Get-GitHubEvent -OwnerName $ownerName -RepositoryName $repositoryName)
 
             Context 'For getting an event directly'{

--- a/Tests/GitHubMilestones.tests.ps1
+++ b/Tests/GitHubMilestones.tests.ps1
@@ -118,7 +118,7 @@ try
         }
 
         Context 'For getting milestones from a repo' {
-            $existingMilestones = @(Get-GitHubMilestone -Uri $repo.svn_url -State "Closed")
+            $existingMilestones = @(Get-GitHubMilestone -Uri $repo.svn_url -State Closed)
             $issue = Get-GitHubIssue -Uri $repo.svn_url -Issue $issue.number
 
             It 'Should have the expected number of milestones' {
@@ -151,7 +151,7 @@ try
         }
 
         Context 'For getting milestones from a repository and deleting them' {
-            $existingMilestones = @(Get-GitHubMilestone -Uri $repo.svn_url -State "All" -Sort "Completeness" -Direction "Descending")
+            $existingMilestones = @(Get-GitHubMilestone -Uri $repo.svn_url -State All -Sort Completeness -Direction Descending)
 
             It 'Should have the expected number of milestones' {
                 $existingMilestones.Count | Should be 2

--- a/Tests/GitHubRepositoryForks.tests.ps1
+++ b/Tests/GitHubRepositoryForks.tests.ps1
@@ -83,7 +83,7 @@ try
 
         Context 'When a new fork is created' {
             $repo = New-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub
-            $newForks = Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Sort newest
+            $newForks = Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Sort Newest
 
             It 'Should have one more fork than before' {
                 (@($newForks).Count - @($originalForks).Count) | Should be 1
@@ -102,7 +102,7 @@ try
 
         Context 'When a new fork is created' {
             $repo = New-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -OrganizationName $script:organizationName
-            $newForks = Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Sort newest
+            $newForks = Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Sort Newest
 
             It 'Should have one more fork than before' {
                 (@($newForks).Count - @($originalForks).Count) | Should be 1

--- a/USAGE.md
+++ b/USAGE.md
@@ -56,7 +56,7 @@
         *   [Get events from a repository](#get-events-from-a-repository)
         *   [Get events from an issue](#get-events-from-an-issue)
         *   [Get a single event](#get-a-single-event])
-        
+
 ----------
 
 ## Logging
@@ -175,7 +175,7 @@ $issues | Where-Object { $_.created_at -gt (Get-Date).AddDays(-14) }
 $repos = @('https://github.com/powershell/xpsdesiredstateconfiguration', 'https://github.com/powershell/xactivedirectory')
 $issues = @()
 $repos | ForEach-Object { $issues += Get-GitHubIssue -Uri $_ }
-$issues | Group-GitHubIssue -Weeks 12 -DateType 'created'
+$issues | Group-GitHubIssue -Weeks 12 -DateType Created
 ```
 
 ```powershell
@@ -213,7 +213,7 @@ $pullRequests | Where-Object { $_.created_at -gt (Get-Date).AddDays(-14) }
 $repos = @('https://github.com/powershell/xpsdesiredstateconfiguration', 'https://github.com/powershell/xactivedirectory')
 $pullRequests = @()
 $repos | ForEach-Object { $pullRequests += Get-GitHubPullRequest -Uri $_ }
-$pullRequests | Group-GitHubPullRequest -Weeks 12 -DateType 'merged'
+$pullRequests | Group-GitHubPullRequest -Weeks 12 -DateType Merged
 ```
 
 ```powershell
@@ -382,12 +382,12 @@ Get-GitHubPathTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub
 
 #### Get the number of views for a repository
 ```powershell
-Get-GitHubViewTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Per 'week'
+Get-GitHubViewTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Per Week
 ```
 
 #### Get the number of clones for a repository
 ```powershell
-Get-GitHubCloneTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Per 'day'
+Get-GitHubCloneTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Per Day
 ```
 
 ----------
@@ -425,7 +425,7 @@ Get-GitHubIssueComment -OwnerName Powershell -RepositoryName PowerShellForGitHub
 
 #### Get comments from a repository
 ```powershell
-Get-GitHubRepositoryComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -Sort created -Direction asc -Since '2011-04-14T16:00:49Z'
+Get-GitHubRepositoryComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -Sort Created -Direction Ascending -Since '2011-04-14T16:00:49Z'
 ```
 
 #### Get a single comment
@@ -454,7 +454,7 @@ Remove-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -
 
 #### Get milestones from a repository
 ```powershell
-Get-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Sort "due_on" -Direction "asc" -DueOn '2011-04-14T16:00:49Z'
+Get-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Sort DueOn -Direction Ascending -DueOn '2011-04-14T16:00:49Z'
 ```
 
 #### Get a single milestone
@@ -465,7 +465,7 @@ Get-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -M
 #### Assign an existing issue to a new milestone
 ```powershell
 New-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Title "Testing this API"
-Update-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 2 -Milestone 1 
+Update-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 2 -Milestone 1
 ```
 
 #### Editing an existing milestone


### PR DESCRIPTION
Updated all parameter sets to use `CamelCased` inputs, and adjusted their usage
internally to still conform to the API requirements.

Made minor documentation changes related to these udpates.

Resolves #65: Fix all string parameters to be CamelCased and avoid abbreviation