### PR TITLE
Update Split-GitHubUri to work with the api.github.com URI's as well

### DIFF
--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -735,7 +735,8 @@ function Split-GitHubUri
         repositoryName = [String]::Empty
     }
 
-    if ($Uri -match '^https?://(?:www.)?github.com/([^/]+)/?([^/]+)?(?:/.*)?$')
+    if (($Uri -match '^https?://(?:www.)?github.com/([^/]+)/?([^/]+)?(?:/.*)?$') -or
+        ($Uri -match '^https?://api.github.com/repos/([^/]+)/?([^/]+)?(?:/.*)?$'))
     {
         $components.ownerName = $Matches[1]
         if ($Matches.Count -gt 2)


### PR DESCRIPTION
These can be seen when running `Get-GitHubIssue` and looking at:

* `url`
* `repository_url`
* `labels_url`
* `comments_url`
* `events_url`