### PR TITLE
Add Test-GitHubOrganizationMember

### DIFF
--- a/GitHubOrganizations.ps1
+++ b/GitHubOrganizations.ps1
@@ -61,3 +61,81 @@ function Get-GitHubOrganizationMember
 
     return Invoke-GHRestMethodMultipleResult @params
 }
+
+function Test-GitHubOrganizationMember
+{
+<#
+    .SYNOPSIS
+        Check to see if a user is a member of an organization.
+
+    .DESCRIPTION
+        Check to see if a user is a member of an organization.
+
+        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
+
+    .PARAMETER OrganizationName
+        The name of the organization.
+
+    .PARAMETER UserName
+        The name of the user being inquired about.
+
+    .PARAMETER AccessToken
+        If provided, this will be used as the AccessToken for authentication with the
+        REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
+
+    .PARAMETER NoStatus
+        If this switch is specified, long-running commands will run on the main thread
+        with no commandline status update.  When not specified, those commands run in
+        the background, enabling the command prompt to provide status information.
+        If not supplied here, the DefaultNoStatus configuration property value will be used.
+
+    .OUTPUTS
+        [Bool]
+
+    .EXAMPLE
+        Test-GitHubOrganizationMember -OrganizationName PowerShell -UserName Octocat
+#>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [CmdletBinding(SupportsShouldProcess)]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String] $OrganizationName,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String] $UserName,
+
+        [string] $AccessToken,
+
+        [switch] $NoStatus
+    )
+
+    Write-InvocationLog
+
+    $telemetryProperties = @{
+        'OrganizationName' = (Get-PiiSafeString -PlainText $OrganizationName)
+    }
+
+    $params = @{
+        'UriFragment' = "orgs/$OrganizationName/members/$UserName"
+        'Description' =  "Checking if $UserName is a member of $OrganizationName"
+        'Method' = 'Get'
+        'ExtendedResult' = $true
+        'AccessToken' = $AccessToken
+        'TelemetryEventName' = $MyInvocation.MyCommand.Name
+        'TelemetryProperties' = $telemetryProperties
+        'NoStatus' = (Resolve-ParameterWithDefaultConfigurationValue -Name NoStatus -ConfigValueName DefaultNoStatus)
+    }
+
+    try
+    {
+        $result = Invoke-GHRestMethod @params
+        return ($result.statusCode -eq 204)
+    }
+    catch
+    {
+        return $false
+    }
+}

--- a/PowerShellForGitHub.psd1
+++ b/PowerShellForGitHub.psd1
@@ -111,6 +111,7 @@
         'Split-GitHubUri',
         'Test-GitHubAssignee',
         'Test-GitHubAuthenticationConfigured',
+        'Test-GitHubOrganizationMember',
         'Unlock-GitHubIssue',
         'Update-GitHubCurrentUser',
         'Update-GitHubIssue',


### PR DESCRIPTION
* _Added_ `Test-GitHubOrganizationMember` to check to see if a user is in an organization.
    * No UT was added for this, because we would only be able to test for the negative case since the API can't create new users.
* _Updated_ `Get-GitHubTeamMember` to optionally work directly with a `TeamId` (instead of it always implicitly looking it up when being given the `TeamName`).
    * Similarly for Teams -- more of the API set needs to be built out before this can be individually tested.