### PR TITLE
Fixing PSScriptAnalyzer error for Test-GitHubOrganizationMember

### DIFF
--- a/GitHubOrganizations.ps1
+++ b/GitHubOrganizations.ps1
@@ -97,6 +97,7 @@ function Test-GitHubOrganizationMember
 #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
     [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([bool])]
     param
     (
         [Parameter(Mandatory)]


### PR DESCRIPTION
Was failing on PSUseOutputTypeCorrectly:
  The cmdlet 'Test-GitHubOrganizationMember' returns an object of type 'System.Boolean'
  but this type is not declared in the OutputType attribute.