### PR TITLE
Rename ConvertFrom-Markdown

### DIFF
--- a/GitHubMiscellaneous.ps1
+++ b/GitHubMiscellaneous.ps1
@@ -73,7 +73,7 @@ function Get-GitHubRateLimit
     return Invoke-GHRestMethod @params
 }
 
-function ConvertFrom-Markdown
+function ConvertFrom-GitHubMarkdown
 {
 <#
     .SYNOPSIS
@@ -113,7 +113,7 @@ function ConvertFrom-Markdown
         [String] The HTML version of the Markdown content.
 
     .EXAMPLE
-        ConvertFrom-Markdown -Content '**Bolded Text**' -Mode Markdown
+        ConvertFrom-GitHubMarkdown -Content '**Bolded Text**' -Mode Markdown
 
         Returns back '<p><strong>Bolded Text</strong></p>'
 #>

--- a/PowerShellForGitHub.psd1
+++ b/PowerShellForGitHub.psd1
@@ -48,7 +48,7 @@
         'Add-GitHubIssueLabel',
         'Backup-GitHubConfiguration',
         'Clear-GitHubAuthentication',
-        'ConvertFrom-Markdown',
+        'ConvertFrom-GitHubMarkdown',
         'Get-GitHubAssignee',
         'Get-GitHubCloneTraffic',
         'Get-GitHubCodeOfConduct',


### PR DESCRIPTION
PowerShellCore 6 added a `ConvertFrom-Markdown` command, and this module's
command therefore causes a conflict.

Renaming to `ConvertFrom-GitHubMarkdown` in an effort to best identify this
as being a "GitHub" method that converts Markdown, although it unfortunately
does imply that it might only support "GitHub Flavored Markdown", where in fact
it supports both that as well as standard.

Resolves #99 - Rename ConvertFrom-Markdown